### PR TITLE
Swift2

### DIFF
--- a/AERecord.xcodeproj/project.pbxproj
+++ b/AERecord.xcodeproj/project.pbxproj
@@ -185,6 +185,7 @@
 		8BC895431A07930500778DB0 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
+				LastSwiftUpdateCheck = 0700;
 				LastUpgradeCheck = 0610;
 				ORGANIZATIONNAME = ae;
 				TargetAttributes = {
@@ -374,7 +375,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
 				INFOPLIST_FILE = AERecordExample/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_NAME = AERecordExample;
 			};
@@ -386,7 +387,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
 				INFOPLIST_FILE = AERecordExample/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_NAME = AERecordExample;
 			};

--- a/AERecord/AERecord.swift
+++ b/AERecord/AERecord.swift
@@ -331,7 +331,7 @@ private class AEStack {
                     } else {
                         if let err = error {
                             if kAERecordPrintLog {
-                                print("Error occured in \(NSStringFromClass(self.dynamicType)) - function: \(__FUNCTION__) | line: \(__LINE__)\n\(err)")
+                                print("Error occured in \(NSStringFromClass(self)) - function: \(__FUNCTION__) | line: \(__LINE__)\n\(err)")
                             }
                         }
                     }

--- a/AERecord/AERecord.swift
+++ b/AERecord/AERecord.swift
@@ -738,8 +738,6 @@ public class CoreDataTableViewController: UITableViewController, NSFetchedResult
             case .Move:
                 tableView.deleteRowsAtIndexPaths([indexPath!], withRowAnimation: .Fade)
                 tableView.insertRowsAtIndexPaths([newIndexPath!], withRowAnimation: .Fade)
-            default:
-                return
             }
         }
     }

--- a/AERecordExample/DetailViewController.swift
+++ b/AERecordExample/DetailViewController.swift
@@ -40,7 +40,7 @@ class DetailViewController: CoreDataCollectionViewController {
         
         let addFewAction = UIAlertAction(title: "Add Few", style: .Default) { (action) -> Void in
             // create few objects
-            for i in 1...5 {
+            for _ in 1...5 {
                 Event.createWithAttributes(["timeStamp" : NSDate()])
             }
             AERecord.saveContextAndWait()
@@ -61,7 +61,7 @@ class DetailViewController: CoreDataCollectionViewController {
                 self.performFetch()
             } else {
                 // < iOS 8
-                println("Batch updating is new in iOS 8.")
+                print("Batch updating is new in iOS 8.")
                 // update all objects through context
                 if let events = Event.all() as? [Event] {
                     for e in events {

--- a/AERecordExample/Images.xcassets/LaunchImage.launchimage/Contents.json
+++ b/AERecordExample/Images.xcassets/LaunchImage.launchimage/Contents.json
@@ -3,43 +3,30 @@
     {
       "orientation" : "portrait",
       "idiom" : "ipad",
-      "minimum-system-version" : "7.0",
       "extent" : "full-screen",
-      "scale" : "2x"
-    },
-    {
-      "orientation" : "landscape",
-      "idiom" : "ipad",
       "minimum-system-version" : "7.0",
-      "extent" : "full-screen",
       "scale" : "1x"
     },
     {
       "orientation" : "landscape",
       "idiom" : "ipad",
-      "minimum-system-version" : "7.0",
       "extent" : "full-screen",
-      "scale" : "2x"
-    },
-    {
-      "orientation" : "portrait",
-      "idiom" : "iphone",
       "minimum-system-version" : "7.0",
-      "scale" : "2x"
-    },
-    {
-      "orientation" : "portrait",
-      "idiom" : "iphone",
-      "minimum-system-version" : "7.0",
-      "subtype" : "retina4",
-      "scale" : "2x"
+      "scale" : "1x"
     },
     {
       "orientation" : "portrait",
       "idiom" : "ipad",
-      "minimum-system-version" : "7.0",
       "extent" : "full-screen",
-      "scale" : "1x"
+      "minimum-system-version" : "7.0",
+      "scale" : "2x"
+    },
+    {
+      "orientation" : "landscape",
+      "idiom" : "ipad",
+      "extent" : "full-screen",
+      "minimum-system-version" : "7.0",
+      "scale" : "2x"
     }
   ],
   "info" : {

--- a/AERecordExample/MasterViewController.swift
+++ b/AERecordExample/MasterViewController.swift
@@ -50,7 +50,7 @@ class MasterViewController: CoreDataTableViewController, UISplitViewControllerDe
     // MARK: - Table View
 
     override func tableView(tableView: UITableView, cellForRowAtIndexPath indexPath: NSIndexPath) -> UITableViewCell {
-        let cell = tableView.dequeueReusableCellWithIdentifier("Cell", forIndexPath: indexPath) as! UITableViewCell
+        let cell = tableView.dequeueReusableCellWithIdentifier("Cell", forIndexPath: indexPath) as UITableViewCell
         self.configureCell(cell, atIndexPath: indexPath)
         return cell
     }
@@ -79,8 +79,8 @@ class MasterViewController: CoreDataTableViewController, UISplitViewControllerDe
     override func tableView(tableView: UITableView, commitEditingStyle editingStyle: UITableViewCellEditingStyle, forRowAtIndexPath indexPath: NSIndexPath) {
         if editingStyle == .Delete {
             // delete object
-            if let event = fetchedResultsController?.objectAtIndexPath(indexPath) as? NSManagedObject {
-                event.delete()
+            if let event = fetchedResultsController?.objectAtIndexPath(indexPath) {
+                event.deleteFromContext()
                 AERecord.saveContext()
             }
         }
@@ -102,7 +102,7 @@ class MasterViewController: CoreDataTableViewController, UISplitViewControllerDe
     
     // MARK: - UISplitViewControllerDelegate
     
-    func splitViewController(splitViewController: UISplitViewController, collapseSecondaryViewController secondaryViewController: UIViewController!, ontoPrimaryViewController primaryViewController: UIViewController!) -> Bool {
+    func splitViewController(splitViewController: UISplitViewController, collapseSecondaryViewController secondaryViewController: UIViewController, ontoPrimaryViewController primaryViewController: UIViewController) -> Bool {
         return collapseDetailViewController
     }
 


### PR DESCRIPTION
Hello @tadija, I've migrated the `AERecord` code base to swift 2.0 syntax. The migration tool wasn't very helpful here because we had a lot of `do try catch` usecases to handle. I've also removed a few `as?` conversions because most `CoreData` methods uses the proper classes now (rather than `AnyObject`).

Let me know if you have any questions or feedback.