### PR TITLE
tvOS support

### DIFF
--- a/AERecord.podspec
+++ b/AERecord.podspec
@@ -11,5 +11,6 @@ s.social_media_url = 'http://twitter.com/tadija'
 s.source = { :git => 'https://github.com/tadija/AERecord.git', :tag => 'AERecord-v'+String(s.version) }
 s.source_files = 'AERecord/*.swift'
 s.ios.deployment_target = '8.0'
+s.tvos.deployment_target = '9.0'
 s.osx.deployment_target = '10.10'
 end

--- a/AERecord/AERecord.swift
+++ b/AERecord/AERecord.swift
@@ -51,9 +51,10 @@ public class AERecord {
         Returns the final URL in Application Documents Directory for the store with given name.
     
         :param: name Filename for the store.
+        :param: searchPath search path directory (default is .DocumentDirectory)
     */
-    public class func storeURLForName(name: String) -> NSURL {
-        return AEStack.storeURLForName(name)
+    public class func storeURLForName(name: String, searchPath: NSSearchPathDirectory = .DocumentDirectory) -> NSURL {
+        return AEStack.storeURLForName(name,searchPath: searchPath)
     }
     
     /**
@@ -201,8 +202,8 @@ private class AEStack {
     
     // MARK: Setup Stack
     
-    class func storeURLForName(name: String) -> NSURL {
-        let applicationDocumentsDirectory = NSFileManager.defaultManager().URLsForDirectory(.DocumentDirectory, inDomains: .UserDomainMask).last!
+    class func storeURLForName(name: String, searchPath: NSSearchPathDirectory = .DocumentDirectory) -> NSURL {
+        let applicationDocumentsDirectory = NSFileManager.defaultManager().URLsForDirectory(searchPath, inDomains: .UserDomainMask).last!
         let storeName = "\(name).sqlite"
         return applicationDocumentsDirectory.URLByAppendingPathComponent(storeName)
     }


### PR DESCRIPTION
I've updated podspec file and added support for specifying NSSearchPathDirectory for method storeURLForName. The reason is that app cannot access Documents directory on real device, and CachesDirectory must be used.