### PR TITLE
Support for static UITableViewControllers

### DIFF
--- a/AECoreDataUI.podspec
+++ b/AECoreDataUI.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
 s.name = 'AECoreDataUI'
-s.version = '2.0.0'
+s.version = '2.0.1'
 s.license = { :type => 'MIT', :file => 'LICENSE' }
 s.summary = 'Super awesome Core Data driven UI in Swift (for iOS)'
 

--- a/AECoreDataUI/AECoreDataUI.swift
+++ b/AECoreDataUI/AECoreDataUI.swift
@@ -195,7 +195,7 @@ public class CoreDataTableViewController: UITableViewController, NSFetchedResult
         :returns: The number of sections in tableView.
     */
     public override func numberOfSectionsInTableView(tableView: UITableView) -> Int {
-        return fetchedResultsController?.sections?.count ?? 0
+        return fetchedResultsController?.sections?.count ?? super.numberOfSectionsInTableView(tableView)
     }
     
     /**
@@ -207,7 +207,7 @@ public class CoreDataTableViewController: UITableViewController, NSFetchedResult
         :returns: The number of rows in section.
     */
     public override func tableView(tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return (fetchedResultsController?.sections?[section])?.numberOfObjects ?? 0
+        return (fetchedResultsController?.sections?[section])?.numberOfObjects ?? super.tableView(tableView, numberOfRowsInSection: section)
     }
     
     /**

--- a/AECoreDataUI/AECoreDataUI.swift
+++ b/AECoreDataUI/AECoreDataUI.swift
@@ -219,7 +219,7 @@ public class CoreDataTableViewController: UITableViewController, NSFetchedResult
         :returns: A string to use as the title of the section header.
     */
     public override func tableView(tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
-        return (fetchedResultsController?.sections?[section])?.name
+        return (fetchedResultsController?.sections?[section])?.name ?? super.tableView(tableView, titleForHeaderInSection: section)
     }
     
     /**


### PR DESCRIPTION
Sometimes it's suitable to use AECoreDataUI with static UITableViewController in Storyboard. But there is a problem when fetch controller is attached after initialisation. So I return super number of sections and super number of row per section.