### PR TITLE
Generic version of methods for creating and finding

### DIFF
--- a/AERecord/AERecord.swift
+++ b/AERecord/AERecord.swift
@@ -675,6 +675,19 @@ public extension NSManagedObject {
     }
     
     /**
+     Finds all records. Generic version.
+     
+     :param: sortDescriptors Sort descriptors.
+     :param: context If not specified, `defaultContext` will be used.
+     
+     :returns: Optional array of `Self` instances.
+     */
+    class func all<T>(sortDescriptors: [NSSortDescriptor]? = nil, context: NSManagedObjectContext = AERecord.defaultContext) -> [T]? {
+        let objects: [NSManagedObject]? = all(sortDescriptors, context: context)
+        return objects?.map { $0 as! T }
+    }
+    
+    /**
         Finds all records for given predicate.
         
         :param: predicate Predicate.

--- a/AERecord/AERecord.swift
+++ b/AERecord/AERecord.swift
@@ -524,6 +524,21 @@ public extension NSManagedObject {
         return objects.first ?? nil
     }
     
+    // MARK: Finding First
+    
+    /**
+    Finds the first record. Generic version.
+    
+    :param: sortDescriptors Sort descriptors.
+    :param: context If not specified, `defaultContext` will be used.
+    
+    :returns: Optional instance of `Self`.
+    */
+    class func first<T>(sortDescriptors sortDescriptors: [NSSortDescriptor]? = nil, context: NSManagedObjectContext = AERecord.defaultContext) -> T? {
+        let object: NSManagedObject? = first(sortDescriptors: sortDescriptors, context: context)
+        return object as? T
+    }
+    
     /**
         Finds the first record for given predicate.
         

--- a/AERecord/AERecord.swift
+++ b/AERecord/AERecord.swift
@@ -644,6 +644,20 @@ public extension NSManagedObject {
         return first(sortDescriptors: sortDescriptors, context: context)
     }
     
+    /**
+     Finds the first record ordered by given attribute. Generic version.
+     
+     :param: name Attribute name.
+     :param: ascending A Boolean value.
+     :param: context If not specified, `defaultContext` will be used.
+     
+     :returns: Optional instance of `Self`.
+     */
+    class func firstOrderedByAttribute<T>(name: String, ascending: Bool = true, context: NSManagedObjectContext = AERecord.defaultContext) -> T? {
+        let object: NSManagedObject? = firstOrderedByAttribute(name, ascending: ascending, context: context)
+        return object as? T
+    }
+    
     // MARK: Finding All
     
     /**

--- a/AERecord/AERecord.swift
+++ b/AERecord/AERecord.swift
@@ -703,6 +703,20 @@ public extension NSManagedObject {
     }
     
     /**
+     Finds all records for given predicate. Generic version
+     
+     :param: predicate Predicate.
+     :param: sortDescriptors Sort descriptors.
+     :param: context If not specified, `defaultContext` will be used.
+     
+     :returns: Optional array of `Self` instances.
+     */
+    class func allWithPredicate<T>(predicate: NSPredicate, sortDescriptors: [NSSortDescriptor]? = nil, context: NSManagedObjectContext = AERecord.defaultContext) -> [T]? {
+        let objects: [NSManagedObject]? = allWithPredicate(predicate, sortDescriptors: sortDescriptors, context: context)
+        return objects?.map { $0 as! T }
+    }
+    
+    /**
         Finds all records for given attribute and value.
         
         :param: attribute Attribute name.

--- a/AERecord/AERecord.swift
+++ b/AERecord/AERecord.swift
@@ -475,6 +475,22 @@ public extension NSManagedObject {
     }
     
     /**
+     Finds the first record for given attribute and value or creates new if the it does not exist. Generic version.
+     
+     :param: attribute Attribute name.
+     :param: value Attribute value.
+     :param: sortDescriptors Sort descriptors.
+     :param: context If not specified, `defaultContext` will be used.
+     
+     :returns: Instance of `Self`.
+     */
+    
+    class func firstOrCreateWithAttribute<T>(attribute: String, value: AnyObject, context: NSManagedObjectContext = AERecord.defaultContext) -> T {
+        let object: NSManagedObject? = firstOrCreateWithAttribute(attribute, value: value, context: context)
+        return object as! T
+    }
+    
+    /**
         Finds the first record for given attributes or creates new if the it does not exist.
         
         :param: attributes Dictionary of attribute names and values.
@@ -539,6 +555,22 @@ public extension NSManagedObject {
         return firstWithPredicate(predicate, sortDescriptors: sortDescriptors, context: context)
     }
     
+    /**
+     Finds the first record for given attribute and value. Generic version.
+     
+     :param: attribute Attribute name.
+     :param: value Attribute value.
+     :param: sortDescriptors Sort descriptors.
+     :param: context If not specified, `defaultContext` will be used.
+     
+     :returns: Optional object of `Self`.
+     */
+    
+    class func firstWithAttribute<T>(attribute: String, value: AnyObject, sortDescriptors: [NSSortDescriptor]? = nil, context: NSManagedObjectContext = AERecord.defaultContext) -> T? {
+        let object: NSManagedObject? = firstWithAttribute(attribute, value: value, sortDescriptors: sortDescriptors, context: context)
+        return object as? T
+    }
+
     /**
         Finds the first record for given attributes.
         

--- a/AERecord/AERecord.swift
+++ b/AERecord/AERecord.swift
@@ -556,6 +556,20 @@ public extension NSManagedObject {
     }
     
     /**
+     Finds the first record for given predicate. Generic version
+     
+     :param: predicate Predicate.
+     :param: sortDescriptors Sort descriptors.
+     :param: context If not specified, `defaultContext` will be used.
+     
+     :returns: Optional managed object.
+     */
+    class func firstWithPredicate<T>(predicate: NSPredicate, sortDescriptors: [NSSortDescriptor]? = nil, context: NSManagedObjectContext = AERecord.defaultContext) -> T? {
+        let object: NSManagedObject? = firstWithPredicate(predicate, sortDescriptors: sortDescriptors, context: context)
+        return object as? T
+    }
+    
+    /**
         Finds the first record for given attribute and value.
         
         :param: attribute Attribute name.

--- a/AERecord/AERecord.swift
+++ b/AERecord/AERecord.swift
@@ -614,6 +614,21 @@ public extension NSManagedObject {
         let predicate = createPredicateForAttributes(attributes, predicateType: predicateType)
         return firstWithPredicate(predicate, sortDescriptors: sortDescriptors, context: context)
     }
+    
+    /**
+     Finds the first record for given attributes. Generic version.
+     
+     :param: attributes Dictionary of attribute names and values.
+     :param: predicateType If not specified, `.AndPredicateType` will be used.
+     :param: sortDescriptors Sort descriptors.
+     :param: context If not specified, `defaultContext` will be used.
+     
+     :returns: Optional instance of `Self`.
+     */
+    class func firstWithAttributes<T>(attributes: [NSObject : AnyObject], predicateType: NSCompoundPredicateType = defaultPredicateType, sortDescriptors: [NSSortDescriptor]? = nil, context: NSManagedObjectContext = AERecord.defaultContext) -> T? {
+        let object: NSManagedObject? = firstWithAttributes(attributes, predicateType: predicateType, sortDescriptors: sortDescriptors, context: context)
+        return object as? T
+    }
 
     /**
         Finds the first record ordered by given attribute.

--- a/AERecord/AERecord.swift
+++ b/AERecord/AERecord.swift
@@ -761,6 +761,21 @@ public extension NSManagedObject {
         return allWithPredicate(predicate, sortDescriptors: sortDescriptors, context: context)
     }
     
+    /**
+     Finds all records for given attributes. Generic version.
+     
+     :param: attributes Dictionary of attribute names and values.
+     :param: predicateType If not specified, `.AndPredicateType` will be used.
+     :param: sortDescriptors Sort descriptors.
+     :param: context If not specified, `defaultContext` will be used.
+     
+     :returns: Optional array of `Self` instances.
+     */
+    class func allWithAttributes<T>(attributes: [NSObject : AnyObject], predicateType: NSCompoundPredicateType = defaultPredicateType, sortDescriptors: [NSSortDescriptor]? = nil, context: NSManagedObjectContext = AERecord.defaultContext) -> [T]? {
+        let objects: [NSManagedObject]? = allWithAttributes(attributes, predicateType: predicateType, sortDescriptors: sortDescriptors, context: context)
+        return objects?.map { $0 as! T }
+    }
+    
     // MARK: Deleting
     
     /**

--- a/AERecord/AERecord.swift
+++ b/AERecord/AERecord.swift
@@ -732,6 +732,21 @@ public extension NSManagedObject {
     }
     
     /**
+     Finds all records for given attribute and value. Generic version
+     
+     :param: attribute Attribute name.
+     :param: value Attribute value.
+     :param: sortDescriptors Sort descriptors.
+     :param: context If not specified, `defaultContext` will be used.
+     
+     :returns: Optional array of `Self` instances.
+     */
+    class func allWithAttribute<T>(attribute: String, value: AnyObject, sortDescriptors: [NSSortDescriptor]? = nil, context: NSManagedObjectContext = AERecord.defaultContext) -> [T]? {
+        let objects: [NSManagedObject]? = allWithAttribute(attribute, value: value, sortDescriptors: sortDescriptors, context: context)
+        return objects?.map { $0 as! T }
+    }
+    
+    /**
         Finds all records for given attributes.
         
         :param: attributes Dictionary of attribute names and values.

--- a/AERecordExample/MasterViewController.swift
+++ b/AERecordExample/MasterViewController.swift
@@ -91,7 +91,7 @@ class MasterViewController: CoreDataTableViewController, UISplitViewControllerDe
         if let frc = fetchedResultsController {
             if let event = frc.objectAtIndexPath(indexPath) as? Event {
                 // deselect previous / select current
-                if let previous = Event.firstWithAttribute("selected", value: true) as? Event {
+                if let previous: Event = Event.firstWithAttribute("selected", value: true) {
                     previous.selected = false
                 }
                 event.selected = true


### PR DESCRIPTION
In order to be able to write 
```swift
let user: User = User.firstOrCreateWithAttribute("id", value: 123)
```
or 
```swift
func newUser() -> User {
    return User.firstOrCreateWithAttribute("id", value: 123)
}
```
instead of 
```swift
let user = User.firstOrCreateWithAttribute("id", value: 123) as! User
```
or 
```swift
func newUser() -> User {
    return User.firstOrCreateWithAttribute("id", value: 123) as! User
}
```