### PR TITLE
Removes explicit type declaration

### DIFF
--- a/AERecord/AERecord.swift
+++ b/AERecord/AERecord.swift
@@ -513,8 +513,8 @@ public extension NSManagedObject {
     
         :returns: Instance of managed object.
     */
-    class func firstOrCreateWithAttribute(attribute: String, value: AnyObject, context: NSManagedObjectContext = AERecord.defaultContext) -> NSManagedObject {
-        return firstOrCreateWithAttributes([attribute : value], context: context)
+    class func firstOrCreateWithAttribute(attribute: String, value: AnyObject, context: NSManagedObjectContext = AERecord.defaultContext) -> Self {
+        return _firstOrCreateWithAttribute(attribute, value: value, context: context)
     }
     
     /**
@@ -526,8 +526,9 @@ public extension NSManagedObject {
 
         :returns: Instance of `Self`.
     */
-    class func firstOrCreateWithAttribute<T>(attribute: String, value: AnyObject, context: NSManagedObjectContext = AERecord.defaultContext) -> T {
-        let object = firstOrCreateWithAttribute(attribute, value: value, context: context)
+    private class func _firstOrCreateWithAttribute<T>(attribute: String, value: AnyObject, context: NSManagedObjectContext = AERecord.defaultContext) -> T {
+        let object = firstOrCreateWithAttributes([attribute : value], context: context)
+        
         return object as! T
     }
     
@@ -540,12 +541,8 @@ public extension NSManagedObject {
         
         :returns: Instance of managed object.
     */
-    class func firstOrCreateWithAttributes(attributes: [String : AnyObject], predicateType: NSCompoundPredicateType = defaultPredicateType, context: NSManagedObjectContext = AERecord.defaultContext) -> NSManagedObject {
-        let predicate = createPredicateForAttributes(attributes, predicateType: predicateType)
-        let request = createFetchRequest(predicate: predicate)
-        request.fetchLimit = 1
-        let objects = AERecord.executeFetchRequest(request, context: context)
-        return objects.first ?? createWithAttributes(attributes, context: context)
+    class func firstOrCreateWithAttributes(attributes: [String : AnyObject], predicateType: NSCompoundPredicateType = defaultPredicateType, context: NSManagedObjectContext = AERecord.defaultContext) -> Self {
+        return _firstOrCreateWithAttributes(attributes, predicateType: predicateType, context: context)
     }
     
     /**
@@ -557,9 +554,13 @@ public extension NSManagedObject {
 
         :returns: Instance of `Self`.
     */
-    class func firstOrCreateWithAttributes<T>(attributes: [String : AnyObject], predicateType: NSCompoundPredicateType = defaultPredicateType, context: NSManagedObjectContext = AERecord.defaultContext) -> T {
-        let object = firstOrCreateWithAttributes(attributes, predicateType: predicateType, context: context)
-        return object as! T
+    private class func _firstOrCreateWithAttributes<T>(attributes: [String : AnyObject], predicateType: NSCompoundPredicateType = defaultPredicateType, context: NSManagedObjectContext = AERecord.defaultContext) -> T {
+        let predicate = createPredicateForAttributes(attributes, predicateType: predicateType)
+        let request = createFetchRequest(predicate: predicate)
+        request.fetchLimit = 1
+        let objects = AERecord.executeFetchRequest(request, context: context)
+        
+        return (objects.first ?? createWithAttributes(attributes, context: context)) as! T
     }
     
     // MARK: Find First
@@ -572,11 +573,8 @@ public extension NSManagedObject {
     
         :returns: Optional managed object.
     */
-    class func first(sortDescriptors sortDescriptors: [NSSortDescriptor]? = nil, context: NSManagedObjectContext = AERecord.defaultContext) -> NSManagedObject? {
-        let request = createFetchRequest(sortDescriptors: sortDescriptors)
-        request.fetchLimit = 1
-        let objects = AERecord.executeFetchRequest(request, context: context)
-        return objects.first ?? nil
+    class func first(sortDescriptors sortDescriptors: [NSSortDescriptor]? = nil, context: NSManagedObjectContext = AERecord.defaultContext) -> Self? {
+        return _first(sortDescriptors: sortDescriptors, context: context)
     }
     
     /**
@@ -587,9 +585,12 @@ public extension NSManagedObject {
 
         :returns: Optional instance of `Self`.
     */
-    class func first<T>(sortDescriptors sortDescriptors: [NSSortDescriptor]? = nil, context: NSManagedObjectContext = AERecord.defaultContext) -> T? {
-        let object = first(sortDescriptors: sortDescriptors, context: context)
-        return object as? T
+    private class func _first<T>(sortDescriptors sortDescriptors: [NSSortDescriptor]? = nil, context: NSManagedObjectContext = AERecord.defaultContext) -> T? {
+        let request = createFetchRequest(sortDescriptors: sortDescriptors)
+        request.fetchLimit = 1
+        let objects = AERecord.executeFetchRequest(request, context: context)
+        
+        return objects.first as? T
     }
     
     /**
@@ -601,11 +602,8 @@ public extension NSManagedObject {
         
         :returns: Optional managed object.
     */
-    class func firstWithPredicate(predicate: NSPredicate, sortDescriptors: [NSSortDescriptor]? = nil, context: NSManagedObjectContext = AERecord.defaultContext) -> NSManagedObject? {
-        let request = createFetchRequest(predicate: predicate, sortDescriptors: sortDescriptors)
-        request.fetchLimit = 1
-        let objects = AERecord.executeFetchRequest(request, context: context)
-        return objects.first ?? nil
+    class func firstWithPredicate(predicate: NSPredicate, sortDescriptors: [NSSortDescriptor]? = nil, context: NSManagedObjectContext = AERecord.defaultContext) -> Self? {
+        return _firstWithPredicate(predicate, sortDescriptors: sortDescriptors, context: context)
     }
     
     /**
@@ -617,9 +615,12 @@ public extension NSManagedObject {
 
         :returns: Optional instance of `Self`.
     */
-    class func firstWithPredicate<T>(predicate: NSPredicate, sortDescriptors: [NSSortDescriptor]? = nil, context: NSManagedObjectContext = AERecord.defaultContext) -> T? {
-        let object = firstWithPredicate(predicate, sortDescriptors: sortDescriptors, context: context)
-        return object as? T
+    private class func _firstWithPredicate<T>(predicate: NSPredicate, sortDescriptors: [NSSortDescriptor]? = nil, context: NSManagedObjectContext = AERecord.defaultContext) -> T? {
+        let request = createFetchRequest(predicate: predicate, sortDescriptors: sortDescriptors)
+        request.fetchLimit = 1
+        let objects = AERecord.executeFetchRequest(request, context: context)
+        
+        return objects.first as? T
     }
     
     /**
@@ -632,24 +633,9 @@ public extension NSManagedObject {
         
         :returns: Optional managed object.
     */
-    class func firstWithAttribute(attribute: String, value: AnyObject, sortDescriptors: [NSSortDescriptor]? = nil, context: NSManagedObjectContext = AERecord.defaultContext) -> NSManagedObject? {
+    class func firstWithAttribute(attribute: String, value: AnyObject, sortDescriptors: [NSSortDescriptor]? = nil, context: NSManagedObjectContext = AERecord.defaultContext) -> Self? {
         let predicate = NSPredicate(format: "%K = %@", argumentArray: [attribute, value])
         return firstWithPredicate(predicate, sortDescriptors: sortDescriptors, context: context)
-    }
-    
-    /**
-        Finds the first record for given attribute and value. Generic version.
-
-        :param: attribute Attribute name.
-        :param: value Attribute value.
-        :param: sortDescriptors Sort descriptors.
-        :param: context If not specified, `defaultContext` will be used.
-
-        :returns: Optional object of `Self`.
-     */
-    class func firstWithAttribute<T>(attribute: String, value: AnyObject, sortDescriptors: [NSSortDescriptor]? = nil, context: NSManagedObjectContext = AERecord.defaultContext) -> T? {
-        let object = firstWithAttribute(attribute, value: value, sortDescriptors: sortDescriptors, context: context)
-        return object as? T
     }
 
     /**
@@ -662,26 +648,11 @@ public extension NSManagedObject {
         
         :returns: Optional managed object.
     */
-    class func firstWithAttributes(attributes: [NSObject : AnyObject], predicateType: NSCompoundPredicateType = defaultPredicateType, sortDescriptors: [NSSortDescriptor]? = nil, context: NSManagedObjectContext = AERecord.defaultContext) -> NSManagedObject? {
+    class func firstWithAttributes(attributes: [NSObject : AnyObject], predicateType: NSCompoundPredicateType = defaultPredicateType, sortDescriptors: [NSSortDescriptor]? = nil, context: NSManagedObjectContext = AERecord.defaultContext) -> Self? {
         let predicate = createPredicateForAttributes(attributes, predicateType: predicateType)
         return firstWithPredicate(predicate, sortDescriptors: sortDescriptors, context: context)
     }
     
-    /**
-        Finds the first record for given attributes. Generic version.
-
-        :param: attributes Dictionary of attribute names and values.
-        :param: predicateType If not specified, `.AndPredicateType` will be used.
-        :param: sortDescriptors Sort descriptors.
-        :param: context If not specified, `defaultContext` will be used.
-
-        :returns: Optional instance of `Self`.
-    */
-    class func firstWithAttributes<T>(attributes: [NSObject : AnyObject], predicateType: NSCompoundPredicateType = defaultPredicateType, sortDescriptors: [NSSortDescriptor]? = nil, context: NSManagedObjectContext = AERecord.defaultContext) -> T? {
-        let object = firstWithAttributes(attributes, predicateType: predicateType, sortDescriptors: sortDescriptors, context: context)
-        return object as? T
-    }
-
     /**
         Finds the first record ordered by given attribute.
         
@@ -691,23 +662,9 @@ public extension NSManagedObject {
         
         :returns: Optional managed object.
     */
-    class func firstOrderedByAttribute(name: String, ascending: Bool = true, context: NSManagedObjectContext = AERecord.defaultContext) -> NSManagedObject? {
+    class func firstOrderedByAttribute(name: String, ascending: Bool = true, context: NSManagedObjectContext = AERecord.defaultContext) -> Self? {
         let sortDescriptors = [NSSortDescriptor(key: name, ascending: ascending)]
         return first(sortDescriptors: sortDescriptors, context: context)
-    }
-    
-    /**
-        Finds the first record ordered by given attribute. Generic version.
-
-        :param: name Attribute name.
-        :param: ascending A Boolean value.
-        :param: context If not specified, `defaultContext` will be used.
-
-        :returns: Optional instance of `Self`.
-    */
-    class func firstOrderedByAttribute<T>(name: String, ascending: Bool = true, context: NSManagedObjectContext = AERecord.defaultContext) -> T? {
-        let object = firstOrderedByAttribute(name, ascending: ascending, context: context)
-        return object as? T
     }
     
     // MARK: Find All

--- a/AERecordExample/DetailViewController.swift
+++ b/AERecordExample/DetailViewController.swift
@@ -118,7 +118,7 @@ class DetailViewController: CoreDataCollectionViewController {
                 if let event = frc.objectAtIndexPath(indexPath) as? Event {
                     cell.backgroundColor = yellow
                     // deselect previous
-                    if let previous = Event.firstWithAttribute("selected", value: true) as? Event {
+                    if let previous = Event.firstWithAttribute("selected", value: true) {
                         previous.selected = false
                         AERecord.saveContextAndWait()
                     }

--- a/AERecordTests/AERecordTests.swift
+++ b/AERecordTests/AERecordTests.swift
@@ -210,10 +210,10 @@ class AERecordTests: XCTestCase {
     // MARK: Find First or Create
     
     func testFirstOrCreateWithAttribute() {
-        let snoopy = Animal.firstOrCreateWithAttribute("name", value: "Snoopy") as! Animal
+        let snoopy = Animal.firstOrCreateWithAttribute("name", value: "Snoopy")
         XCTAssertEqual(snoopy.name, "Snoopy", "Should be able to create record if it doesn't already exist.")
         
-        let tinna = Animal.firstOrCreateWithAttribute("name", value: "Tinna") as! Animal
+        let tinna = Animal.firstOrCreateWithAttribute("name", value: "Tinna")
         XCTAssertEqual(tinna.color, "lightgray", "Should be able to return the first record with given attribute.")
     }
     
@@ -227,11 +227,11 @@ class AERecordTests: XCTestCase {
     
     func testFirstOrCreateWithAttributes() {
         let snoopyAttributes = ["name" : "Snoopy", "color" : "white"]
-        let snoopy = Animal.firstOrCreateWithAttributes(snoopyAttributes) as! Animal
+        let snoopy = Animal.firstOrCreateWithAttributes(snoopyAttributes)
         XCTAssertEqual(snoopy.color, "white", "Should be able to create record if it doesn't already exist.")
         
         let tinnaAttributes = ["name" : "Tinna", "color" : "lightgray"]
-        let tinna = Animal.firstOrCreateWithAttributes(tinnaAttributes) as! Animal
+        let tinna = Animal.firstOrCreateWithAttributes(tinnaAttributes)
         XCTAssertEqual(tinna.color, "lightgray", "Should be able to return the first record with given attributes.")
     }
     
@@ -249,20 +249,20 @@ class AERecordTests: XCTestCase {
     
     func testFirst() {
         let sortDescriptor = NSSortDescriptor(key: "name", ascending: true)
-        let firstAnimal = Animal.first(sortDescriptors: [sortDescriptor]) as! Animal
-        XCTAssertEqual(firstAnimal.name, "Betty", "Should be able to return the first record sorted by given sort descriptor.")
+        let firstAnimal = Animal.first(sortDescriptors: [sortDescriptor])
+        XCTAssertEqual(firstAnimal?.name, "Betty", "Should be able to return the first record sorted by given sort descriptor.")
     }
     
     func testFirstGeneric() {
         let sortDescriptor = NSSortDescriptor(key: "name", ascending: true)
-        let firstAnimal: Animal = Animal.first(sortDescriptors: [sortDescriptor])!
-        XCTAssertEqual(firstAnimal.name, "Betty", "Should be able to return the first record sorted by given sort descriptor.")
+        let firstAnimal = Animal.first(sortDescriptors: [sortDescriptor])
+        XCTAssertEqual(firstAnimal?.name, "Betty", "Should be able to return the first record sorted by given sort descriptor.")
     }
     
     func testFirstWithPredicate() {
         let predicate = NSPredicate(format: "color == %@", "lightgray")
-        let tinna = Animal.firstWithPredicate(predicate) as! Animal
-        XCTAssertEqual(tinna.name, "Tinna", "Should be able to return the first record for given predicate.")
+        let tinna = Animal.firstWithPredicate(predicate)
+        XCTAssertEqual(tinna?.name, "Tinna", "Should be able to return the first record for given predicate.")
     }
     
     func testFirstWithPredicateGeneric() {
@@ -272,8 +272,8 @@ class AERecordTests: XCTestCase {
     }
     
     func testFirstWithAttribute() {
-        let kika = Animal.firstWithAttribute("color", value: "black") as! Animal
-        XCTAssertEqual(kika.name, "Kika", "Should be able to return the first record for given attribute.")
+        let kika = Animal.firstWithAttribute("color", value: "black")
+        XCTAssertEqual(kika?.name, "Kika", "Should be able to return the first record for given attribute.")
     }
     
     func testFirstWithAttributeGeneric() {
@@ -282,8 +282,8 @@ class AERecordTests: XCTestCase {
     }
     
     func testFirstOrderedByAttribute() {
-        let kika = Animal.firstOrderedByAttribute("color", ascending: true) as! Animal
-        XCTAssertEqual(kika.name, "Kika", "Should be able to return the first record ordered by given attribute.")
+        let kika = Animal.firstOrderedByAttribute("color", ascending: true)
+        XCTAssertEqual(kika?.name, "Kika", "Should be able to return the first record ordered by given attribute.")
     }
     
     func testFirstOrderedByAttributeGeneric() {
@@ -293,8 +293,8 @@ class AERecordTests: XCTestCase {
     
     func testFirstWithAttributes() {
         let tinnaAttributes = ["name" : "Tinna", "color" : "lightgray"]
-        let tinna = Animal.firstWithAttributes(tinnaAttributes) as! Animal
-        XCTAssertEqual(tinna.color, "lightgray", "Should be able to return the first record with given attributes.")
+        let tinna = Animal.firstWithAttributes(tinnaAttributes)
+        XCTAssertEqual(tinna?.color, "lightgray", "Should be able to return the first record with given attributes.")
     }
     
     func testFirstWithAttributesGeneric() {
@@ -363,11 +363,11 @@ class AERecordTests: XCTestCase {
     
     func testDelete() {
         let sortDescriptor = NSSortDescriptor(key: "name", ascending: true)
-        let firstAnimal = Animal.first(sortDescriptors: [sortDescriptor]) as! Animal
-        XCTAssertEqual(firstAnimal.name, "Betty", "Should be able to return the first record sorted by given sort descriptor.")
+        let firstAnimal = Animal.first(sortDescriptors: [sortDescriptor])
+        XCTAssertEqual(firstAnimal?.name, "Betty", "Should be able to return the first record sorted by given sort descriptor.")
         
-        firstAnimal.deleteFromContext()
-        let betty = Animal.firstWithAttribute("name", value: "Betty") as? Animal
+        firstAnimal?.deleteFromContext()
+        let betty = Animal.firstWithAttribute("name", value: "Betty")
         XCTAssertNil(betty, "Should be able to delete record.")
     }
     
@@ -382,9 +382,9 @@ class AERecordTests: XCTestCase {
         Animal.deleteAllWithPredicate(predicate)
         
         let animals = Animal.all()
-        let betty = Animal.firstWithAttribute("name", value: "Betty") as? Animal
+        let betty = Animal.firstWithAttribute("name", value: "Betty")
         
-        XCTAssertEqual(animals!.count, 5, "Should be able to delete all records for given predicate.")
+        XCTAssertEqual(animals?.count, 5, "Should be able to delete all records for given predicate.")
         XCTAssertNil(betty, "Should be able to delete all records for given predicate.")
     }
     
@@ -392,9 +392,9 @@ class AERecordTests: XCTestCase {
         Animal.deleteAllWithAttribute("color", value: "white")
         
         let animals = Animal.all()
-        let villy = Animal.firstWithAttribute("name", value: "Villy") as? Animal
+        let villy = Animal.firstWithAttribute("name", value: "Villy")
         
-        XCTAssertEqual(animals!.count, 5, "Should be able to delete all records for given attribute.")
+        XCTAssertEqual(animals?.count, 5, "Should be able to delete all records for given attribute.")
         XCTAssertNil(villy, "Should be able to delete all records for given attribute.")
     }
     


### PR DESCRIPTION
This pull request removes the need to explicitly declare type or force cast from NSManagedObject for find and create methods.

```swift
let cat: Cat = Cat.firstOrCreate()
// or
let cat = Cat.firstOrCreate() as! Cat
```
can be now written as
```swift
let cat = Cat.firstOrCreate()
```

This is sadly not possible for `[Self]` now. Tests adjusted accordingly.