### PR TITLE
Updated README to reflect correct delete function

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ NSManagedObject.allWithAttributes(attributes) // get all objects with given attr
 #### Delete
 ```swift
 let managedObject = ...
-managedObject.delete() // delete object (call on instance)
+managedObject.deleteFromContext() // delete object (call on instance)
 
 NSManagedObject.deleteAll() // delete all objects
 


### PR DESCRIPTION
I believe the correct delete function is `model.deleteFromContext()` rather than `model.delete()` where model is an instantiated NSManagedObject subclass. I looked through the source to find a reference to `delete()` and `deleteFromContext()` was the closest I came to finding something similar. 

If you wanted to implement the `delete()` function for simplicities sake, you could just map it directly to `deleteFromContext()` given that the `context` var is optional and automatically assigned to the default context if not set.